### PR TITLE
Fix p0 for Updated Anemoi Versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Custom additions
 
 **/slurm/
-**/training/output/
+**/training/outputs/
 *.nc
 *.zarr
 

--- a/phase-1/README.md
+++ b/phase-1/README.md
@@ -1,0 +1,9 @@
+# Phase 1
+
+## Anemoi Versions
+
+These yaml files are compatible with the following versions:
+
+```
+pip install anemoi-datasets==0.5.23 anemoi-graphs==0.5.2 anemoi-models==0.5.0 anemoi-training==0.4.0
+pip install 'earthkit-data<0.14.0'

--- a/phase-1/data/conus.training.yaml
+++ b/phase-1/data/conus.training.yaml
@@ -59,6 +59,7 @@ transforms:
 target:
   name: anemoi
   sort_channels_by_levels: True
+  compute_temporal_residual_statistics: True
   rename:
     geopotential_at_surface: orography
     round_land_sea_mask: land_sea_mask

--- a/phase-1/data/conus.validation.yaml
+++ b/phase-1/data/conus.validation.yaml
@@ -59,6 +59,7 @@ transforms:
 target:
   name: anemoi
   sort_channels_by_levels: True
+  compute_temporal_residual_statistics: True
   rename:
     geopotential_at_surface: orography
     round_land_sea_mask: land_sea_mask

--- a/phase-1/data/global.training.yaml
+++ b/phase-1/data/global.training.yaml
@@ -65,6 +65,7 @@ transforms:
 target:
   name: anemoi
   sort_channels_by_levels: True
+  compute_temporal_residual_statistics: True
   rename:
     geopotential_at_surface: orography
     round_land_sea_mask: land_sea_mask

--- a/phase-1/data/global.validation.yaml
+++ b/phase-1/data/global.validation.yaml
@@ -65,6 +65,7 @@ transforms:
 target:
   name: anemoi
   sort_channels_by_levels: True
+  compute_temporal_residual_statistics: True
   rename:
     geopotential_at_surface: orography
     round_land_sea_mask: land_sea_mask

--- a/phase-1/data/submit_ufs2arco.sh
+++ b/phase-1/data/submit_ufs2arco.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 #SBATCH -J nested-era5-data
-#SBATCH -o /pscratch/sd/t/timothys/nested-eagle/phase-2/data/slurm/preprocessing.%j.out
-#SBATCH -e /pscratch/sd/t/timothys/nested-eagle/phase-2/data/slurm/preprocessing.%j.err
+#SBATCH -o /pscratch/sd/t/timothys/nested-eagle/phase-1/data/slurm/preprocessing.%j.out
+#SBATCH -e /pscratch/sd/t/timothys/nested-eagle/phase-1/data/slurm/preprocessing.%j.err
 #SBATCH --nodes=8
 #SBATCH --ntasks-per-node=64
 #SBATCH --cpus-per-task=4

--- a/phase-1/p0/training/config.yaml
+++ b/phase-1/p0/training/config.yaml
@@ -63,8 +63,8 @@ hardware:
   num_gpus_per_model: 1
   paths:
     data: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/data
-    graph: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0
-    output: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0
+    graph: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0/
+    output: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0/
   files:
     dataset: conus.training.zarr
     forcing_dataset: global.training.zarr

--- a/phase-1/p0/training/config.yaml
+++ b/phase-1/p0/training/config.yaml
@@ -1,6 +1,7 @@
 defaults:
 - data: zarr
 - dataloader: native_grid
+- datamodule: single
 - diagnostics: evaluation
 - hardware: slurm
 - graph: stretched_grid
@@ -61,9 +62,9 @@ diagnostics:
 hardware:
   num_gpus_per_model: 1
   paths:
-    output: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0/training-output/
-    data: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0/data
+    data: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/data
     graph: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0
+    output: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0
   files:
     dataset: conus.training.zarr
     forcing_dataset: global.training.zarr

--- a/phase-1/p0/training/data/zarr.yaml
+++ b/phase-1/p0/training/data/zarr.yaml
@@ -28,9 +28,6 @@ normalizer:
   default: mean-std
   std:
     - total_precipitation_6hr
-
-  min-max:
-  max:
   none:
     - cos_latitude
     - sin_latitude

--- a/phase-1/p0/training/datamodule/single.yaml
+++ b/phase-1/p0/training/datamodule/single.yaml
@@ -1,0 +1,1 @@
+_target_: anemoi.training.data.datamodule.AnemoiDatasetsDataModule

--- a/phase-1/p0/training/debug.yaml
+++ b/phase-1/p0/training/debug.yaml
@@ -63,8 +63,8 @@ hardware:
   num_gpus_per_model: 1
   paths:
     data: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/data
-    graph: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0
-    output: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0
+    graph: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0/
+    output: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0/
   files:
     dataset: conus.training.zarr
     forcing_dataset: global.training.zarr

--- a/phase-1/p0/training/debug.yaml
+++ b/phase-1/p0/training/debug.yaml
@@ -1,6 +1,7 @@
 defaults:
 - data: zarr
 - dataloader: native_grid
+- datamodule: single
 - diagnostics: evaluation
 - hardware: slurm
 - graph: stretched_grid
@@ -61,9 +62,9 @@ diagnostics:
 hardware:
   num_gpus_per_model: 1
   paths:
-    output: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0/training-output/
-    data: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0/data
+    data: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/data
     graph: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0
+    output: ${oc.decode:${oc.env:SCRATCH}}/nested-eagle/phase-1/p0
   files:
     dataset: conus.training.zarr
     forcing_dataset: global.training.zarr

--- a/phase-1/p0/training/diagnostics/evaluation.yaml
+++ b/phase-1/p0/training/diagnostics/evaluation.yaml
@@ -48,8 +48,8 @@ log:
     authentication: False
     log_model: False
     tracking_uri: "http://nid200356-hsn0:5000"
-    experiment_name: 'anemoi-debug'
-    project_name: 'nested-conus'
+    experiment_name: 'p0'
+    project_name: 'nested-eagle-phase-1'
     system: True
     terminal: True
     run_name: null # If set to null, the run name will be the a random UUID

--- a/phase-1/p0/training/graph/stretched_grid.yaml
+++ b/phase-1/p0/training/graph/stretched_grid.yaml
@@ -1,0 +1,71 @@
+# Stretched grid graph config intended to be used with a cutout dataset.
+# The stretched mesh resolution used here is intended for o96 global resolution with 10km
+# limited area resolution.
+overwrite: True
+
+data: "data"
+hidden: "hidden"
+
+nodes:
+  data:
+    node_builder:
+      _target_: anemoi.graphs.nodes.ZarrDatasetNodes
+      dataset: ${dataloader.training.dataset}
+    attributes: ${graph.attributes.nodes}
+  hidden:
+    node_builder:
+      _target_: anemoi.graphs.nodes.StretchedTriNodes
+      lam_resolution: 6 #8 #???
+      global_resolution: 5 #???
+      reference_node_name: ${graph.data}
+      mask_attr_name: cutout_mask
+      margin_radius_km: 11 #???
+
+edges:
+# Encoder
+- source_name: ${graph.data}
+  target_name: ${graph.hidden}
+  edge_builders:
+  - _target_: anemoi.graphs.edges.KNNEdges
+    num_nearest_neighbours: 12
+    source_mask_attr_name: null
+    target_mask_attr_name: null
+  attributes: ${graph.attributes.edges}
+# Processor
+- source_name: ${graph.hidden}
+  target_name: ${graph.hidden}
+  edge_builders:
+  - _target_: anemoi.graphs.edges.MultiScaleEdges
+    x_hops: 1
+    scale_resolutions: ${graph.nodes.hidden.node_builder.lam_resolution}
+    source_mask_attr_name: null
+    target_mask_attr_name: null
+  attributes: ${graph.attributes.edges}
+# Decoder
+- source_name: ${graph.hidden}
+  target_name: ${graph.data}
+  edge_builders:
+  - _target_: anemoi.graphs.edges.KNNEdges
+    num_nearest_neighbours: 3
+    source_mask_attr_name: null
+    target_mask_attr_name: null
+  attributes: ${graph.attributes.edges}
+
+attributes:
+  nodes:
+    # Attributes for data nodes
+    area_weight:
+      _target_: anemoi.graphs.nodes.attributes.SphericalAreaWeights
+      norm: unit-max
+      fill_value: 0
+    cutout_mask:
+      _target_: anemoi.graphs.nodes.attributes.CutOutMask
+  edges:
+    edge_length:
+      _target_: anemoi.graphs.edges.attributes.EdgeLength
+      norm: unit-max
+    edge_dirs:
+      _target_: anemoi.graphs.edges.attributes.EdgeDirection
+      norm: unit-std
+
+post_processors: []

--- a/phase-1/p0/training/model/graphtransformer.yaml
+++ b/phase-1/p0/training/model/graphtransformer.yaml
@@ -1,5 +1,5 @@
 activation: GELU
-num_channels: 512
+num_channels: 1024
 cpu_offload: False
 output_mask: null
 
@@ -7,7 +7,38 @@ model:
   _target_: anemoi.models.models.encoder_processor_decoder.AnemoiModelEncProcDec
 
 
+# LayerKernels are optionally. If not specified, the default are pytorch.nn.LayerNorm and torch.nn.Linear.
+# TODO: Add to documentation: The query and key norms need to be autocast layer norms if flash attention is used.
 layer_kernels:
+  processor:
+    LayerNorm:
+      _target_: torch.nn.LayerNorm
+      _partial_: True
+      #Any arguments to your chosen function go here
+    Linear:
+      _target_: torch.nn.Linear
+      _partial_: True
+      #Any arguments to your chosen function go here
+    QueryNorm:
+      _target_: anemoi.models.layers.normalization.AutocastLayerNorm
+      _partial_: True
+      bias: False
+      #Any arguments to your chosen function go here
+    KeyNorm:
+      _target_: anemoi.models.layers.normalization.AutocastLayerNorm
+      _partial_: True
+      bias: False
+      #Any arguments to your chosen function go here
+  encoder:
+    LayerNorm:
+      _target_: torch.nn.LayerNorm
+      _partial_: True
+      #Any arguments to your chosen function go here
+    Linear:
+      _target_: torch.nn.Linear
+      _partial_: True
+      #Any arguments to your chosen function go here
+  decoder:
     LayerNorm:
       _target_: torch.nn.LayerNorm
       _partial_: True
@@ -26,7 +57,9 @@ processor:
   num_chunks: 2
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
+  qk_norm: False
   cpu_offload: ${model.cpu_offload}
+
 
 encoder:
   _target_: anemoi.models.layers.mapper.GraphTransformerForwardMapper
@@ -36,7 +69,9 @@ encoder:
   num_chunks: 1
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
+  qk_norm: False
   cpu_offload: ${model.cpu_offload}
+
 
 decoder:
   _target_: anemoi.models.layers.mapper.GraphTransformerBackwardMapper
@@ -46,7 +81,10 @@ decoder:
   num_chunks: 1
   mlp_hidden_ratio: 4 # GraphTransformer or Transformer only
   num_heads: 16 # GraphTransformer or Transformer only
+  initialise_data_extractor_zero: False
+  qk_norm: False
   cpu_offload: ${model.cpu_offload}
+
 
 trainable_parameters:
   data: 8
@@ -65,7 +103,7 @@ attributes:
 # Bounding configuration
 bounding: #These are applied in order
 
-  # Bound tp (total precipitation) with a Relu bounding layer
+  # Bound total_precipitation with a Relu bounding layer
   # ensuring a range of [0, infinity) to avoid negative precipitation values.
   - _target_: anemoi.models.layers.bounding.ReluBounding #[0, infinity)
     variables:

--- a/phase-1/p0/training/submit_training.sh
+++ b/phase-1/p0/training/submit_training.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#SBATCH -J p0-training
+#SBATCH -o slurm/training.%j.out
+#SBATCH -e slurm/training.%j.err
+#SBATCH --nodes=4
+#SBATCH --tasks-per-node=4
+#SBATCH --gpus-per-node=4
+#SBATCH --cpus-per-task=16
+#SBATCH --qos=regular
+#SBATCH --account=m4718
+#SBATCH --constraint=gpu&hbm80g
+#SBATCH -t 36:00:00
+
+conda activate anemoi
+srun --jobid $SLURM_JOB_ID ~/anemoi-house/slurm2ddp.sh anemoi-training train --config-name=config

--- a/phase-1/p0/training/training/default.yaml
+++ b/phase-1/p0/training/training/default.yaml
@@ -4,9 +4,6 @@ fork_run_id: null
 transfer_learning: False # activate to perform transfer learning
 load_weights_only: False # only load model weights, do not restore optimiser states etc.
 
-# Training method/objective, e.g. forecaster, interpolator.
-task: anemoi.training.train.forecaster.GraphForecaster
-
 # run in deterministic mode ; slows down
 deterministic: False
 
@@ -36,17 +33,27 @@ swa:
   enabled: False
   lr: 1.e-4
 
-# use ZeroRedundancyOptimizer ; saves memory for larger models
+# Optimizer settings
 optimizer:
   zero: False # use ZeroRedundancyOptimizer ; saves memory for larger models
   kwargs:
     betas: [0.9, 0.95]
+
+# select model
+model_task: anemoi.training.train.forecaster.GraphForecaster
+
+# select strategy
+strategy:
+  _target_: anemoi.training.distributed.strategy.DDPGroupStrategy
+  num_gpus_per_model: ${hardware.num_gpus_per_model}
+  read_group_size: ${dataloader.read_group_size}
 
 # loss functions
 
 # dynamic rescaling of the loss gradient
 # see https://arxiv.org/pdf/2306.06079.pdf, section 4.3.2
 # don't enable this by default until it's been tested and proven beneficial
+loss_gradient_scaling: False
 
 # loss function for the model
 training_loss:
@@ -59,8 +66,6 @@ training_loss:
   scalars: ['variable', 'loss_weights_mask']
 
   ignore_nans: False
-
-loss_gradient_scaling: False
 
 # Validation metrics calculation,
 # This may be a list, in which case all metrics will be calculated
@@ -100,13 +105,13 @@ rollout:
 
 # Set max_epochs or max_steps. Training stops at the first limit reached.
 max_epochs: null
-max_steps: 300_000
+max_steps: 150000
 
 lr:
+  warmup: 1000 # number of warmup iterations
   rate: 0.625e-4 #local_lr
   iterations: ${training.max_steps} # NOTE: When max_epochs < max_steps, scheduler will run for max_steps
   min: 3e-7 #Not scaled by #GPU
-  warmup: 1000
 
 # Changes in per-gpu batch_size should come with a rescaling of the local_lr
 # in order to keep a constant global_lr
@@ -114,7 +119,7 @@ lr:
 
 # Variable loss scaling
 # 'variable' must be included in `scalars` in the losses for this to be applied.
-variable_loss_scaling: #??? this whole section
+variable_loss_scaling:
   default: 1
   pl:
     specific_humidity       : 0.6


### PR DESCRIPTION
I forgot that what I dragged into this repo does not work for the most recent (or somewhat most recent) anemoi versions. This is good to go, and I'm retraining the p0 with latent space size of 1024 instead of 512. 